### PR TITLE
优化GitHub Actions工作流只在main分支触发Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   release:
@@ -36,7 +34,6 @@ jobs:
         run: npm run tauri build
 
       - name: Create Release
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.run_number }}


### PR DESCRIPTION
## Summary
- 移除pull_request触发条件，只保留push到main分支的触发
- 简化Create Release步骤的条件判断逻辑
- 确保只有合入主干的代码才会自动发布Release包

## Changes
- 删除了workflow中的pull_request触发条件
- 移除了Create Release步骤中的条件判断
- 优化了自动发布的触发逻辑

## Test plan
- [x] 修改GitHub Actions工作流文件
- [x] 简化触发条件
- [ ] 合并后验证只有main分支会触发Release

🤖 Generated with [Claude Code](https://claude.ai/code)